### PR TITLE
Improve pyvista.StructuredGrid example and docs

### DIFF
--- a/doc/source/api/core/pointsets.rst
+++ b/doc/source/api/core/pointsets.rst
@@ -291,12 +291,12 @@ grid from NumPy arrays.
     import numpy as np
 
     x = np.arange(-10, 10, 1, dtype=np.float32)
-    y = np.arange(-10, 10, 1, dtype=np.float32)
-    z = np.arange(-10, 10, 2, dtype=np.float32)
-    x, y, z = np.meshgrid(x, y, z)
+    y = np.arange(-10, 10, 2, dtype=np.float32)
+    z = np.arange(-10, 10, 5, dtype=np.float32)
+    x, y, z = np.meshgrid(x, y, z, indexing='ij')
 
     # create the unstructured grid directly from the numpy arrays and plot
-    grid = pv.StructuredGrid(x[::-1], y[::-1], z[::-1])
+    grid = pv.StructuredGrid(x, y, z)
     grid.plot(show_edges=True)
 
 

--- a/doc/source/getting-started/why.rst
+++ b/doc/source/getting-started/why.rst
@@ -140,7 +140,8 @@ field of arrows using :func:`numpy.meshgrid`:
     # Make a grid
     x, y, z = np.meshgrid(np.linspace(-5, 5, 20),
                           np.linspace(-5, 5, 20),
-                          np.linspace(-5, 5, 5))
+                          np.linspace(-5, 5, 5), 
+                          indexing='ij')
 
     points = np.empty((x.size, 3))
     points[:, 0] = x.ravel('F')

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2001,18 +2001,18 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
     Create from NumPy arrays.
 
     >>> xrng = np.arange(-10, 10, 2, dtype=np.float32)
-    >>> yrng = np.arange(-10, 10, 2, dtype=np.float32)
-    >>> zrng = np.arange(-10, 10, 2, dtype=np.float32)
-    >>> x, y, z = np.meshgrid(xrng, yrng, zrng)
+    >>> yrng = np.arange(-10, 10, 5, dtype=np.float32)
+    >>> zrng = np.arange(-10, 10, 1, dtype=np.float32)
+    >>> x, y, z = np.meshgrid(xrng, yrng, zrng, indexing='ij')
     >>> grid = pyvista.StructuredGrid(x, y, z)
     >>> grid  # doctest:+SKIP
     StructuredGrid (0x7fb18f2a8580)
-    N Cells:    729
-    N Points:   1000
+    N Cells:    513
+    N Points:   800
     X Bounds:   -1.000e+01, 8.000e+00
-    Y Bounds:   -1.000e+01, 8.000e+00
-    Z Bounds:   -1.000e+01, 8.000e+00
-    Dimensions: 10, 10, 10
+    Y Bounds:   -1.000e+01, 5.000e+00
+    Z Bounds:   -1.000e+01, 9.000e+00
+    Dimensions: 10, 4, 20
     N Arrays:   0
 
     """
@@ -2117,10 +2117,10 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> xrng = np.arange(-10, 10, 1, dtype=np.float32)
         >>> yrng = np.arange(-10, 10, 2, dtype=np.float32)
         >>> zrng = np.arange(-10, 10, 5, dtype=np.float32)
-        >>> x, y, z = np.meshgrid(xrng, yrng, zrng)
+        >>> x, y, z = np.meshgrid(xrng, yrng, zrng, indexing='ij')
         >>> grid = pyvista.StructuredGrid(x, y, z)
         >>> grid.dimensions
-        (10, 20, 4)
+        (20, 10, 4)
 
         """
         return tuple(self.GetDimensions())
@@ -2147,10 +2147,10 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> xrng = np.arange(-10, 10, 1, dtype=np.float32)
         >>> yrng = np.arange(-10, 10, 2, dtype=np.float32)
         >>> zrng = np.arange(-10, 10, 5, dtype=np.float32)
-        >>> x, y, z = np.meshgrid(xrng, yrng, zrng)
+        >>> x, y, z = np.meshgrid(xrng, yrng, zrng, indexing='ij')
         >>> grid = pyvista.StructuredGrid(x, y, z)
         >>> grid.x.shape
-        (10, 20, 4)
+        (20, 10, 4)
 
         """
         return self._reshape_point_array(self.points[:, 0])

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -68,7 +68,7 @@ def voxelize(mesh, density=None, check_surface=True):
     x = np.arange(x_min, x_max, density_x)
     y = np.arange(y_min, y_max, density_y)
     z = np.arange(z_min, z_max, density_z)
-    x, y, z = np.meshgrid(x, y, z)
+    x, y, z = np.meshgrid(x, y, z, indexing='ij')
 
     # Create unstructured grid from the structured grid
     grid = pyvista.StructuredGrid(x, y, z)


### PR DESCRIPTION
### Overview

DocString of class StructuredGrid is updated to show that indexing='ij' option should be applied to prepare x, y, z = np.meshgrid(xrng, yrng, zrng, indexing='ij') .

Details on this document modification can be found at discussion https://github.com/pyvista/pyvista/discussions/4360

Additional change for pull request https://github.com/pyvista/pyvista/pull/4365